### PR TITLE
Use `aarch64` instead of `arm64` for ARM binaries

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -63,6 +63,13 @@ download_release() {
 get_arch() {
   arch=$(uname -m | tr '[:upper:]' '[:lower:]')
 
+  # releases use "aarch64" instead of "arm64"
+  case $arch in
+  arm64)
+    arch='aarch64'
+    ;;
+  esac
+
   echo "$arch"
 }
 


### PR DESCRIPTION
The release binaries for 64-bit ARM platforms are named `aarch64`, not `arm64`